### PR TITLE
Side bar partial fails to honour site.Params.search #60

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,10 +1,12 @@
 <div class="col-lg-4">
+  {{ if site.Params.search }}
   <div class="widget search-box">
     <form action="{{ site.BaseURL }}/search">
       <i class="ti-search"></i>
       <input class="form-control border-0 pl-5" type="search" placeholder="Search" id="search-query" name="s">
     </form>
   </div>
+  {{ end }}
   <div class="widget">
     <h6 class="mb-4">LATEST POST</h6>
     {{ range first 3 ( where site.Pages "Type" "post") }}


### PR DESCRIPTION
Ensure sidebar partial honours site.Params.search, as per the header partial.

Fixes #60 