### PR TITLE
Remove defunct _internal google_analytics_async.html reference #62

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,6 +27,5 @@
   <meta property="og:image" content="{{ . | absURL }}" />
   {{ end }}
   {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/google_analytics_async.html" . }}
 
 </head>


### PR DESCRIPTION
> WARN _internal/google_analytics_async.html is no longer supported
by Google and will be removed in a future version of Hugo

Remove accordingly from head partial.

Fixes #62 